### PR TITLE
Provide a single-threaded notification scheduler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name          = "mio-misc"
-version       = "2.0.6"
+version       = "1.0.0"
 license       = "MIT OR Apache-2.0"
 authors       = ["Onur Ozduygu"]
-description   = "Misc components for use with Mio"
+description   = "Miscellaneous components for use with Mio"
 documentation = "https://docs.rs/mio-misc"
-repository    = "https://github.com/dimbleby/mio-extras"
+repository    = "https://github.com/onurzdg/mio-misc"
 readme        = "README.md"
 keywords      = ["io", "async", "non-blocking"]
 categories    = ["asynchronous"]
@@ -14,8 +14,10 @@ edition       = "2018"
 
 [dependencies]
 mio = {version ="0.7", features = ["os-poll", "tcp"]}
+log = "0.4"
 crossbeam = "0.7"
 crossbeam-queue = "0.2"
+rand = "0.7.3"
 
 [[test]]
 name = "test"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mio-misc
 
-Extra components for use with [Mio](https://github.com/tokio-rs/mio):
+Miscellaneous components for use with [Mio](https://github.com/tokio-rs/mio):
 
 - channels that trigger events on `Poll`
 - schedulers that trigger events on `Poll`

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,46 +1,104 @@
-//! Thread safe communication channel
+//! Thread safe communication channels
+use crate::queue::{NotificationError, Notifier};
+use crate::NotificationId;
+use crossbeam::channel as beamchannel;
 use std::error;
 use std::sync::{mpsc, Arc};
 use std::{fmt, io};
-use crate::NotificationId;
-use crate::queue::{NotificationQueue, SyncNotificationQueue, SyncNotificationError};
 
-/// Creates a new asynchronous channel, where the `Sender::send` function, in addition to sending a message,
-/// queues `NotificationId` and thereby trigger notification on `Poll`
-pub fn channel<T>(queue: Arc<NotificationQueue>, id: NotificationId) -> (Sender<T>, mpsc::Receiver<T>) {
+/// Creates a new asynchronous/unbounded channel, where the `Sender::send` function, in addition to sending a message,
+/// triggers a notification on `Poll`
+pub fn channel<T>(
+    notifier: Arc<dyn Notifier>,
+    id: NotificationId,
+) -> (Sender<T>, mpsc::Receiver<T>) {
     let (tx, rx) = mpsc::channel();
-    let tx = Sender { queue: Arc::clone(&queue), tx, id};
+    let tx = Sender { notifier, tx, id };
     (tx, rx)
 }
 
 /// Creates a new synchronous channel, where the `SyncSender::send` function, in addition to sending a message,
-/// queues `NotificationId` and thereby trigger notification on `Poll`
-pub fn sync_channel<T>(queue: Arc<SyncNotificationQueue>, id: NotificationId, bound_size: usize) -> (SyncSender<T>, mpsc::Receiver<T>) {
+/// triggers a notification on `Poll`
+pub fn sync_channel<T>(
+    notifier: Arc<dyn Notifier>,
+    id: NotificationId,
+    bound_size: usize,
+) -> (SyncSender<T>, mpsc::Receiver<T>) {
     let (tx, rx) = mpsc::sync_channel(bound_size);
-    let tx = SyncSender { queue: Arc::clone(&queue), tx, id};
+    let tx = SyncSender { notifier, tx, id };
+    (tx, rx)
+}
+
+/// Creates a new asynchronous/unbounded crossbeam channel, where the `Sender::send` function, in addition to sending a message,
+/// triggers a notification on `Poll`
+pub fn crossbeam_channel_unbounded<T>(
+    notifier: Arc<dyn Notifier>,
+    id: NotificationId,
+) -> (CrossbeamSender<T>, beamchannel::Receiver<T>) {
+    let (tx, rx) = beamchannel::unbounded();
+    let tx = CrossbeamSender { notifier, tx, id };
+    (tx, rx)
+}
+
+/// Creates a new synchronous/bounded crossbeam channel, where the `Sender::send` function, in addition to sending a message,
+/// triggers a notification on `Poll`
+pub fn crossbeam_channel_bounded<T>(
+    notifier: Arc<dyn Notifier>,
+    id: NotificationId,
+    size: usize,
+) -> (CrossbeamSender<T>, beamchannel::Receiver<T>) {
+    let (tx, rx) = beamchannel::bounded(size);
+    let tx = CrossbeamSender { notifier, tx, id };
     (tx, rx)
 }
 
 /// The sending half of a channel.
 pub struct Sender<T> {
     tx: mpsc::Sender<T>,
-    queue: Arc<NotificationQueue>,
-    id: NotificationId
+    notifier: Arc<dyn Notifier>,
+    id: NotificationId,
 }
 
 impl<T> Sender<T> {
     /// Attempts to send a value on this channel, returning it back if it could not be sent.
     pub fn send(&self, t: T) -> Result<(), SendError<T>> {
         self.tx.send(t).map_err(SendError::from)?;
-        self.queue.push(self.id).map_err(SendError::from)
+        self.notifier.notify(self.id).map_err(SendError::from)
+    }
+}
+
+/// The sending half of a channel crossbeam channel
+pub struct CrossbeamSender<T> {
+    tx: beamchannel::Sender<T>,
+    notifier: Arc<dyn Notifier>,
+    id: NotificationId,
+}
+
+impl<T> CrossbeamSender<T> {
+    /// Attempts to send a value on this channel, returning it back if it could not be sent.
+    /// For bounded channels, it will block.
+    pub fn send(&self, t: T) -> Result<(), SendError<T>> {
+        self.tx.send(t).map_err(SendError::from)?;
+        self.notifier.notify(self.id).map_err(SendError::from)
+    }
+
+    /// Attempts to send a value on this channel without blocking.
+    ///
+    /// This method differs from `send` by returning immediately if the channel's
+    /// buffer is full or no receiver is waiting to acquire some data.
+    pub fn try_send(&self, t: T) -> Result<(), TrySendError<T>> {
+        self.tx
+            .try_send(t)
+            .map_err(From::from)
+            .and_then(|_| self.notifier.notify(self.id).map_err(From::from))
     }
 }
 
 /// The sending half of a synchronous channel.
 pub struct SyncSender<T> {
     tx: mpsc::SyncSender<T>,
-    queue: Arc<SyncNotificationQueue>,
-    id: NotificationId
+    notifier: Arc<dyn Notifier>,
+    id: NotificationId,
 }
 
 impl<T> SyncSender<T> {
@@ -48,20 +106,22 @@ impl<T> SyncSender<T> {
     ///
     /// This function will *block* until space in the internal buffer becomes
     /// available or a receiver is available to hand off the message to.
-    ///
-    pub fn send(&self, t: T) -> Result<(), SyncSendError> {
-        self.tx.send(t).map_err(From::from)
-            .and(self.queue.push(self.id).map_err(From::from))
+    pub fn send(&self, t: T) -> Result<(), SendError<T>> {
+        self.tx
+            .send(t)
+            .map_err(From::from)
+            .and_then(|_| self.notifier.notify(self.id).map_err(From::from))
     }
 
     /// Attempts to send a value on this channel without blocking.
     ///
     /// This method differs from `send` by returning immediately if the channel's
     /// buffer is full or no receiver is waiting to acquire some data.
-    pub fn try_send(&self, t: T) -> Result<(), SyncTrySendError> {
-        self.tx.try_send(t).map_err(From::from).and(
-            self.queue.push(self.id).map_err(From::from)
-        )
+    pub fn try_send(&self, t: T) -> Result<(), TrySendError<T>> {
+        self.tx
+            .try_send(t)
+            .map_err(From::from)
+            .and_then(|_| self.notifier.notify(self.id).map_err(From::from))
     }
 }
 
@@ -71,34 +131,10 @@ pub enum SendError<T> {
     Io(io::Error),
 
     /// The receiving half of the channel has disconnected.
-    Disconnected(T)
-}
+    Disconnected(T),
 
-/// An error returned from the `SyncSender::send` function.
-pub enum SyncSendError {
-    /// An IO error.
-    Io(io::Error),
-
-    /// The receiving half of the channel has disconnected.
-    Disconnected,
-
-    /// Failed to add notification
-    NotificationFailed
-}
-
-/// An error returned from the `SyncSender::try_send` function
-pub enum SyncTrySendError {
-    /// An IO error.
-    Io(io::Error),
-
-    /// The receiving half of the channel has disconnected.
-    Disconnected,
-
-    /// Failed to add notification
-    NotificationFailed,
-
-    /// Full
-    Full
+    /// Underlying notification queue is full
+    NotificationQueueFull,
 }
 
 /// An error returned from the `SyncSender::try_send` function.
@@ -106,19 +142,22 @@ pub enum TrySendError<T> {
     /// An IO error.
     Io(io::Error),
 
-    /// Data could not be sent because it would require the callee to block.
+    /// Data could not be sent over the channel because it would require the callee to block.
     Full(T),
 
     /// The receiving half of the channel has disconnected.
     Disconnected(T),
+
+    /// Underlying notification queue is full
+    NotificationQueueFull,
 }
 
 impl<T> Clone for Sender<T> {
     fn clone(&self) -> Sender<T> {
         Sender {
             tx: self.tx.clone(),
-            queue: Arc::clone(&self.queue),
-            id: self.id
+            notifier: Arc::clone(&self.notifier),
+            id: self.id,
         }
     }
 }
@@ -127,15 +166,15 @@ impl<T> Clone for SyncSender<T> {
     fn clone(&self) -> SyncSender<T> {
         SyncSender {
             tx: self.tx.clone(),
-            queue: Arc::clone(&self.queue),
-            id: self.id
+            notifier: Arc::clone(&self.notifier),
+            id: self.id,
         }
     }
 }
 
 /*
  *
- * ===== Error conversions =====
+ * ===== Implement Error conversions =====
  *
  */
 
@@ -151,21 +190,15 @@ impl<T> From<io::Error> for SendError<T> {
     }
 }
 
-impl<T> From<mpsc::SendError<T>> for SyncSendError {
-    fn from(_: mpsc::SendError<T>) -> Self {
-        SyncSendError::Disconnected
+impl<T> From<beamchannel::SendError<T>> for SendError<T> {
+    fn from(src: beamchannel::SendError<T>) -> Self {
+        SendError::Disconnected(src.0)
     }
 }
 
-impl From<io::Error> for SyncSendError {
-    fn from(src: io::Error) -> Self {
-        SyncSendError::Io(src)
-    }
-}
-
-impl From<SyncNotificationError<NotificationId>> for SyncSendError {
-    fn from(_: SyncNotificationError<NotificationId>) -> Self {
-        SyncSendError::NotificationFailed
+impl<T> From<NotificationError<NotificationId>> for SendError<T> {
+    fn from(_: NotificationError<NotificationId>) -> Self {
+        SendError::NotificationQueueFull
     }
 }
 
@@ -178,27 +211,18 @@ impl<T> From<mpsc::TrySendError<T>> for TrySendError<T> {
     }
 }
 
-impl<T> From<SyncNotificationError<T>> for SyncTrySendError {
-    fn from(src: SyncNotificationError<T>) -> Self {
-        match src {
-            SyncNotificationError::Full(_) => SyncTrySendError::NotificationFailed,
-            SyncNotificationError::Io(src) => SyncTrySendError::Io(src),
-        }
+impl<T> From<NotificationError<NotificationId>> for TrySendError<T> {
+    fn from(_: NotificationError<NotificationId>) -> Self {
+        TrySendError::NotificationQueueFull
     }
 }
 
-impl <T> From<mpsc::TrySendError<T>> for SyncTrySendError {
-    fn from(src: mpsc::TrySendError<T>) -> Self {
+impl<T> From<beamchannel::TrySendError<T>> for TrySendError<T> {
+    fn from(src: beamchannel::TrySendError<T>) -> Self {
         match src {
-            mpsc::TrySendError::Full(_) => SyncTrySendError::Full,
-            mpsc::TrySendError::Disconnected(_) => SyncTrySendError::Disconnected,
+            beamchannel::TrySendError::Full(v) => TrySendError::Full(v),
+            beamchannel::TrySendError::Disconnected(v) => TrySendError::Disconnected(v),
         }
-    }
-}
-
-impl From<io::Error> for SyncTrySendError {
-    fn from(src: io::Error) -> Self {
-        SyncTrySendError::Io(src)
     }
 }
 
@@ -216,18 +240,13 @@ impl<T> From<io::Error> for TrySendError<T> {
 
 /*
  *
- * ===== Implement Error, Debug and Display for Errors =====
+ * ===== Implement Error, Debug, and Display for Errors =====
  *
  */
 
 impl<T> error::Error for SendError<T> {}
 
-impl error::Error for SyncSendError {}
-
 impl<T> error::Error for TrySendError<T> {}
-
-impl error::Error for SyncTrySendError {}
-
 
 impl<T> fmt::Debug for SendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -238,30 +257,6 @@ impl<T> fmt::Debug for SendError<T> {
 impl<T> fmt::Display for SendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         format_send_error(self, f)
-    }
-}
-
-impl fmt::Debug for SyncSendError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        format_sync_send_error(self, f)
-    }
-}
-
-impl fmt::Display for SyncSendError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        format_sync_send_error(self, f)
-    }
-}
-
-impl fmt::Debug for SyncTrySendError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        format_sync_try_send_error(self, f)
-    }
-}
-
-impl fmt::Display for SyncTrySendError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        format_sync_try_send_error(self, f)
     }
 }
 
@@ -281,26 +276,8 @@ impl<T> fmt::Display for TrySendError<T> {
 fn format_send_error<T>(e: &SendError<T>, f: &mut fmt::Formatter) -> fmt::Result {
     match e {
         SendError::Io(ref io_err) => write!(f, "{}", io_err),
-        SendError::Disconnected(..) => write!(f, "Disconnected"),
-    }
-}
-
-#[inline]
-fn format_sync_send_error(e: &SyncSendError, f: &mut fmt::Formatter) -> fmt::Result {
-    match e {
-        SyncSendError::Io(ref io_err) => write!(f, "{}", io_err),
-        SyncSendError::Disconnected => write!(f, "Disconnected"),
-        SyncSendError::NotificationFailed => write!(f, "Notification failed"),
-    }
-}
-
-#[inline]
-fn format_sync_try_send_error(e: &SyncTrySendError, f: &mut fmt::Formatter) -> fmt::Result {
-    match e {
-        SyncTrySendError::Io(ref io_err) => write!(f, "{}", io_err),
-        SyncTrySendError::Disconnected => write!(f, "Disconnected"),
-        SyncTrySendError::NotificationFailed => write!(f, "Notification failed"),
-        SyncTrySendError::Full => write!(f, "Channel full"),
+        SendError::Disconnected(_) => write!(f, "Disconnected"),
+        SendError::NotificationQueueFull => write!(f, "Notification queue full"),
     }
 }
 
@@ -310,5 +287,6 @@ fn format_try_send_error<T>(e: &TrySendError<T>, f: &mut fmt::Formatter) -> fmt:
         TrySendError::Io(ref io_err) => write!(f, "{}", io_err),
         TrySendError::Full(..) => write!(f, "Channel full"),
         TrySendError::Disconnected(..) => write!(f, "Disconnected"),
+        TrySendError::NotificationQueueFull => write!(f, "Notification queue full"),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,30 +1,33 @@
-//! Extra components for use with Mio.
+//! Miscellaneous components for use with Mio.
 #![deny(missing_docs)]
-extern crate mio;
 extern crate crossbeam;
+extern crate mio;
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+#[macro_use]
+extern crate log;
+
+use std::sync::atomic::{AtomicU32, Ordering};
 
 pub mod channel;
-pub mod scheduler;
 pub mod poll;
 pub mod queue;
+pub mod scheduler;
 
-static NOTIFICATION_ID: AtomicUsize = AtomicUsize::new(1);
+static NEXT_NOTIFICATION_ID: AtomicU32 = AtomicU32::new(1);
 
-/// NotificationId
+/// Used while sending notifications
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct NotificationId {id: usize}
+pub struct NotificationId(u32);
 
 impl NotificationId {
-    /// Generates next `NotificationId`, which is guaranteed to be unique
+    /// Generates the next `NotificationId`, which is guaranteed to be unique
     pub fn gen_next() -> NotificationId {
-        let id = NOTIFICATION_ID.fetch_add(1, Ordering::SeqCst);
-        NotificationId{id}
+        let id = NEXT_NOTIFICATION_ID.fetch_add(1, Ordering::SeqCst);
+        NotificationId(id)
     }
 
     /// Returns id
-    pub fn id(&self) -> usize {
-        self.id
+    pub fn id(&self) -> u32 {
+        self.0
     }
 }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,32 +1,34 @@
-//! Wrapper around `mio::Poll` to offer a more convenient API
+//! Wrapper around `mio::Poll` to offer a slightly more convenient API
 use mio::Registry;
-use std::time::Duration;
 use std::io;
+use std::time::Duration;
 
 /// Encapsulates `mio::Poll` and `mio::Events`
 pub struct Poll {
     poll: mio::Poll,
-    events: mio::Events
+    events: mio::Events,
 }
 
 impl Poll {
-    /// Creates a `Poller`
+    /// Creates a `Poll`
     pub fn with_capacity(capacity: usize) -> io::Result<Poll> {
         let poll = mio::Poll::new()?;
         Ok(Poll {
             poll,
-            events:mio::Events::with_capacity(capacity)
+            events: mio::Events::with_capacity(capacity),
         })
     }
 
     /// Polls until the provided duration and returns `Events`
-    pub fn wait<I>(&mut self, timeout: I) -> io::Result<&mio::Events> where
-        I: Into<Option<Duration>> {
+    pub fn wait<I>(&mut self, timeout: I) -> io::Result<&mio::Events>
+    where
+        I: Into<Option<Duration>>,
+    {
         let _ = self.poll.poll(&mut self.events, timeout.into())?;
         Ok(&self.events)
     }
 
-    /// Gets `Poller` registry
+    /// Returns registry
     pub fn registry(&self) -> &Registry {
         self.poll.registry()
     }

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -1,9 +1,10 @@
 extern crate mio;
 extern crate mio_misc;
+extern crate rand;
 
-use mio::{Token, Interest};
-use std::time::Duration;
+use mio::{Interest, Token};
 use mio_misc::poll::Poll;
+use std::time::Duration;
 
 mod test_poll_channel;
 mod test_scheduler;
@@ -11,23 +12,18 @@ mod test_scheduler;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct TestEvent {
     token: Token,
-    interest: Interest
+    interest: Interest,
 }
 
-pub fn expect_events(
-    poll: &mut Poll,
-    poll_try_count: usize,
-    mut expected: Vec<TestEvent>
-) {
+pub fn expect_events(poll: &mut Poll, poll_try_count: usize, mut expected: Vec<TestEvent>) {
     let poll_timeout = Duration::from_secs(2);
 
     for _ in 0..poll_try_count {
-        let events = poll.wait(poll_timeout)
-            .unwrap();
+        let events = poll.wait(poll_timeout).unwrap();
         for event in events.iter() {
-            let pos_opt = expected.iter().position(|exp_event| {
-                event.token() == exp_event.token
-            });
+            let pos_opt = expected
+                .iter()
+                .position(|exp_event| event.token() == exp_event.token);
             if let Some(pos) = pos_opt {
                 expected.remove(pos);
             }

--- a/test/test_scheduler.rs
+++ b/test/test_scheduler.rs
@@ -1,12 +1,15 @@
 use mio::{Token, Waker};
 
-use mio_misc::{scheduler, poll, scheduler::Scheduler, NotificationId, queue::NotificationQueue};
-use std::sync::atomic::{Ordering, AtomicU32};
-use std::sync::Arc;
-use std::time::Duration;
+use mio_misc::scheduler::{NotificationScheduler, ScheduleEntry, SchedulerStatus};
+use mio_misc::{poll, queue::NotificationQueue, scheduler::Scheduler, NotificationId};
+use rand::seq::SliceRandom;
+use rand::Rng;
 use std::collections::HashMap;
+use std::ops::{Add, Sub};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Barrier, Mutex, RwLock};
 use std::thread;
-use std::ops::Add;
+use std::time::Duration;
 
 #[test]
 pub fn test_notification_scheduler() {
@@ -15,37 +18,42 @@ pub fn test_notification_scheduler() {
     let waker = Arc::new(Waker::new(poll.registry(), waker_token).unwrap());
     let queue = Arc::new(NotificationQueue::new(waker));
 
+    let notifier = Arc::clone(&queue);
     let id1 = NotificationId::gen_next();
-    let scheduler1 =
-        scheduler::NotificationScheduler::notify_with_fixed_interval(
-            id1, Arc::clone(&queue), Duration::from_millis(1), None);
+
+    let scheduler = NotificationScheduler::new(notifier, Arc::new(Scheduler::default()));
+    scheduler.notify_with_fixed_interval(
+        id1,
+        Duration::from_millis(1),
+        None,
+        Some("notification-name-1".into()),
+    );
 
     let id2 = NotificationId::gen_next();
-    let scheduler2 =
-        scheduler::NotificationScheduler::notify_with_fixed_interval(
-            id2, Arc::clone(&queue), Duration::from_millis(1), None);
+    scheduler.notify_with_fixed_interval(
+        id2,
+        Duration::from_millis(1),
+        None,
+        Some("notification-name-2".into()),
+    );
 
-    thread::sleep(Duration::from_millis(3));
+    thread::sleep(Duration::from_millis(33));
 
     let events = poll.wait(Duration::from_millis(1)).unwrap();
     assert!(!events.is_empty());
     assert_eq!(events.iter().next().unwrap().token(), waker_token);
     assert!(queue.len() >= 4);
 
-    let mut map: HashMap<NotificationId, u32> = [(id1, 2), (id2, 2)]
-        .iter().cloned().collect();
+    let mut map: HashMap<NotificationId, u32> = [(id1, 2), (id2, 2)].iter().cloned().collect();
 
-    let update_counts = |_|
-        { let _ = map.entry(queue.pop().unwrap())
-            .and_modify(|v|*v -= 1);
-        };
+    let update_counts = |_| {
+        let _ = map.entry(queue.pop().unwrap()).and_modify(|v| *v -= 1);
+    };
 
     (1..=4).for_each(update_counts);
 
+    // make sure we at least we get two notifications of each id
     assert!(map.iter().all(|(_, &count)| count == 0));
-
-    assert!(scheduler1.cancel().is_ok());
-    assert!(scheduler2.cancel().is_ok());
 }
 
 #[test]
@@ -53,62 +61,310 @@ pub fn test_scheduler_with_fixed_interval() {
     let atomic_int = Arc::new(AtomicU32::new(0));
     let interval = Duration::from_millis(2);
     let atomic_int_2 = Arc::clone(&atomic_int);
-    let sh = Scheduler::schedule_with_fixed_interval(interval,
-                                                     None,
-                                                     move || { atomic_int_2.fetch_add(1, Ordering::SeqCst); });
-    thread::sleep(interval.add(Duration::from_millis(5)));
-    assert!(sh.cancel().is_ok());
+    let scheduler = Scheduler::default();
+    let entry =
+        ScheduleEntry::with_interval(interval, None, Some("increment-int".into()), move || {
+            atomic_int_2.fetch_add(1, Ordering::SeqCst);
+        });
+    let entry_id = entry.id;
+    scheduler.schedule(entry);
+
+    thread::sleep(interval.add(Duration::from_millis(15)));
+    scheduler.cancel(entry_id);
 
     let called_times = atomic_int.load(Ordering::SeqCst);
     assert!(called_times >= 2);
+
+    thread::sleep(Duration::from_millis(20));
+    assert_eq!(scheduler.status(), SchedulerStatus::Parked);
 }
 
 #[test]
 pub fn test_scheduler_with_fixed_interval_cancel() {
     let atomic_int = Arc::new(AtomicU32::new(0));
-    let interval = Duration::from_millis(5);
-    let atomic_int_2 = Arc::clone(&atomic_int);
-    let sh = Scheduler::schedule_with_fixed_interval(interval,
-                                                     None,
-                                                     move || { atomic_int_2.fetch_add(1, Ordering::SeqCst); });
-    assert!(sh.cancel().is_ok());
+    let atomic_int_clone = Arc::clone(&atomic_int);
+    let interval = Duration::from_millis(500);
+    let entry =
+        ScheduleEntry::with_interval(interval, Duration::from_millis(200), None, move || {
+            atomic_int_clone.fetch_add(1, Ordering::SeqCst);
+        });
+    let entry_id_1 = entry.id;
+    let scheduler = Scheduler::default();
+    scheduler.schedule(entry);
+
+    scheduler.cancel(entry_id_1);
     let called_times = atomic_int.load(Ordering::SeqCst);
     assert_eq!(called_times, 0);
 
-    let atomic_int_3 = Arc::clone(&atomic_int);
-    let sh = Scheduler::schedule_with_fixed_interval(interval,
-                                                     Duration::from_secs(2),
-                                                     move || { atomic_int_3.fetch_add(1, Ordering::SeqCst); });
+    let atomic_int_clone2 = Arc::clone(&atomic_int);
+    let entry2 = ScheduleEntry::with_interval(
+        Duration::from_millis(800),
+        Duration::from_millis(200),
+        None,
+        move || {
+            atomic_int_clone2.fetch_add(1, Ordering::SeqCst);
+        },
+    );
+    let entry_id_2 = entry2.id;
+    scheduler.schedule(entry2);
 
-    thread::sleep(Duration::from_millis(500));
-    assert!(sh.cancel().is_ok());
+    // wait for the entry to be scheduled
+    thread::sleep(Duration::from_millis(50));
+    scheduler.cancel(entry_id_2);
+    let possible_states = vec![SchedulerStatus::ParkedTimeout, SchedulerStatus::Active];
+    assert!(possible_states.contains(&scheduler.status()));
+
     let called_times = atomic_int.load(Ordering::SeqCst);
     assert_eq!(called_times, 0);
+
+    thread::sleep(Duration::from_millis(200));
+    assert_eq!(scheduler.status(), SchedulerStatus::Parked);
 }
 
 #[test]
 pub fn test_scheduler_one_time() {
     let atomic_int = Arc::new(AtomicU32::new(0));
-    let interval = Duration::from_millis(2);
-    let atomic_int_2 = Arc::clone(&atomic_int);
-    let sh = Scheduler::schedule_one_time(interval,
-                                          move || { atomic_int_2.fetch_add(1, Ordering::SeqCst); });
-    thread::sleep(interval.add(Duration::from_millis(4)));
-    assert!(sh.cancel().is_ok());
+    let atomic_int_clone = Arc::clone(&atomic_int);
 
+    let delay = Duration::from_millis(20);
+    let scheduler = Scheduler::default();
+    let possible_states = vec![SchedulerStatus::Parked, SchedulerStatus::Active];
+    assert!(possible_states.contains(&scheduler.status()));
+
+    let entry = ScheduleEntry::one_time(delay, None, move || {
+        atomic_int_clone.fetch_add(1, Ordering::SeqCst);
+    });
+    scheduler.schedule(entry);
+    // wait to be able to test with certainty that it won't be executed multiple times
+    thread::sleep(delay.add(Duration::from_millis(40)));
     let called_times = atomic_int.load(Ordering::SeqCst);
     assert_eq!(called_times, 1);
+
+    let atomic_int_clone_2 = Arc::clone(&atomic_int);
+    let entry2 = ScheduleEntry::one_time(Duration::from_millis(200), None, move || {
+        atomic_int_clone_2.fetch_add(1, Ordering::SeqCst);
+    });
+    scheduler.schedule(entry2);
+    // wait for entry to be scheduled
+    thread::sleep(Duration::from_millis(100));
+    assert_eq!(scheduler.status(), SchedulerStatus::ParkedTimeout);
+
+    // wait just enough for the entry to be executed
+    thread::sleep(Duration::from_millis(110));
+    let called_times = atomic_int.load(Ordering::SeqCst);
+    assert_eq!(called_times, 2);
+    assert_eq!(scheduler.status(), SchedulerStatus::Parked);
+
+    let atomic_int_clone_3 = Arc::clone(&atomic_int);
+    let entry3 = ScheduleEntry::one_time(Duration::from_millis(110), None, move || {
+        atomic_int_clone_3.fetch_add(1, Ordering::SeqCst);
+    });
+    scheduler.schedule(entry3);
+    // wait just enough for the entry to be in the queue
+    thread::sleep(Duration::from_millis(50));
+    assert_eq!(scheduler.status(), SchedulerStatus::ParkedTimeout);
 }
 
 #[test]
-pub fn test_cancel_scheduler_one_time() {
+pub fn test_scheduler_one_time_cancel() {
     let atomic_int = Arc::new(AtomicU32::new(0));
-    let atomic_int_2 = Arc::clone(&atomic_int);
-    let sh = Scheduler::schedule_one_time(Duration::from_millis(40),
-                                          move || { atomic_int_2.fetch_add(1, Ordering::SeqCst); });
+    let atomic_int_clone = Arc::clone(&atomic_int);
+    let scheduler = Scheduler::default();
+    let delay = Duration::from_millis(40);
+    let entry = ScheduleEntry::one_time(delay, None, move || {
+        atomic_int_clone.fetch_add(1, Ordering::SeqCst);
+    });
+    let entry_id_1 = entry.id;
+    scheduler.schedule(entry);
 
-    thread::sleep(Duration::from_millis(15));
-    assert!(sh.cancel().is_ok());
+    // wait less than the delay assigned to entry so that we prevent the function from being executed
+    thread::sleep(delay.sub(Duration::from_millis(15)));
+    scheduler.cancel(entry_id_1);
     let called_times = atomic_int.load(Ordering::SeqCst);
     assert_eq!(called_times, 0);
+
+    let atomic_int_clone2 = Arc::clone(&atomic_int);
+    let entry2 = ScheduleEntry::one_time(delay, None, move || {
+        atomic_int_clone2.fetch_add(1, Ordering::SeqCst);
+    });
+    let entry_id_2 = entry2.id;
+    scheduler.schedule(entry2);
+
+    // wait more than the delay assigned to schedule entry so that cancel gets called after entry execution
+    thread::sleep(delay.add(Duration::from_millis(15)));
+    scheduler.cancel(entry_id_2);
+    let called_times = atomic_int.load(Ordering::SeqCst);
+    assert_eq!(called_times, 1);
+
+    // verifying that no execution happens after the previous one
+    thread::sleep(delay.add(Duration::from_millis(15)));
+    let called_times = atomic_int.load(Ordering::SeqCst);
+    assert_eq!(called_times, 1);
+    assert_eq!(scheduler.status(), SchedulerStatus::Parked);
+}
+
+#[test]
+pub fn stress_test_execution() {
+    let scheduler = Scheduler::default();
+    let mut rng = rand::thread_rng();
+
+    let map: Arc<RwLock<HashMap<u32, Mutex<u32>>>> = Arc::new(RwLock::new(HashMap::new()));
+    let total_entries = 50;
+    let mut entry_ids = Vec::with_capacity(total_entries);
+
+    for idx in 1..=(total_entries as u32) {
+        let interval = Duration::from_millis(rng.gen_range(1, 101));
+        let map_clone = Arc::clone(&map);
+        let entry =
+            ScheduleEntry::with_interval(interval, None, Some("increment-int".into()), move || {
+                let map_read_guard = map_clone.read().expect("RwLock poisoned");
+                if let Some(entry) = map_read_guard.get(&idx) {
+                    let mut elem = entry.lock().expect("Mutex poisoned");
+                    *elem += 1;
+                } else {
+                    drop(map_read_guard); // drop read lock
+                    let mut map_write_guard = map_clone.write().expect("RwLock poisoned");
+                    map_write_guard.entry(idx).or_insert_with(|| Mutex::new(1));
+                }
+            });
+        entry_ids.push(entry.id);
+        scheduler.schedule(entry);
+    }
+
+    // wait for entries to be scheduled and run
+    thread::sleep(Duration::from_secs(10));
+
+    assert_eq!(
+        scheduler.entry_count(),
+        total_entries as u32,
+        "entry count should match after initial scheduling of entries"
+    );
+    assert_eq!(
+        entry_ids.len(),
+        total_entries as usize,
+        "entry id count should match after initial scheduling of entries"
+    );
+    assert!(
+        map.read()
+            .unwrap()
+            .iter()
+            .all(|(_, count)| *(count.lock().unwrap()) > 0),
+        "all entries should have be executed"
+    );
+
+    entry_ids.shuffle(&mut rng);
+    let removed_entries = entry_ids.split_off(total_entries / 2);
+    for removed_entry in removed_entries {
+        scheduler.cancel(removed_entry);
+    }
+
+    // wait for entries to be cancelled
+    thread::sleep(Duration::from_secs(5));
+
+    // remove all entries from map
+    map.write().unwrap().clear();
+
+    // wait for remaining entries to keep executing
+    thread::sleep(Duration::from_secs(10));
+
+    assert_eq!(
+        scheduler.entry_count(),
+        (total_entries / 2) as u32,
+        "new entry count should match after cancellations"
+    );
+    assert!(
+        map.read()
+            .unwrap()
+            .iter()
+            .all(|(_, count)| *(count.lock().unwrap()) > 0),
+        "all remaining entries should have continued to execute"
+    );
+}
+
+#[test]
+pub fn stress_test_execution_with_multiple_threads() {
+    let scheduler = Arc::new(Scheduler::default());
+    let mut rng = rand::thread_rng();
+    let barrier = Arc::new(Barrier::new(10));
+
+    let map: Arc<RwLock<HashMap<u32, Mutex<u32>>>> = Arc::new(RwLock::new(HashMap::new()));
+    let total_entries = 10;
+    let mut entry_ids = Vec::with_capacity(total_entries);
+    let mut thread_handles = Vec::with_capacity(total_entries);
+
+    for idx in 1..=(total_entries as u32) {
+        let interval = Duration::from_millis(rng.gen_range(1, 101));
+        let map_clone = Arc::clone(&map);
+        let entry =
+            ScheduleEntry::with_interval(interval, None, Some("increment-int".into()), move || {
+                let map_read_guard = map_clone.read().expect("RwLock poisoned");
+                if let Some(entry) = map_read_guard.get(&idx) {
+                    let mut elem = entry.lock().expect("Mutex poisoned");
+                    *elem += 1;
+                } else {
+                    drop(map_read_guard); // drop read lock
+                    let mut map_write_guard = map_clone.write().expect("RwLock poisoned");
+                    map_write_guard.entry(idx).or_insert_with(|| Mutex::new(1));
+                }
+            });
+        entry_ids.push(entry.id);
+        let barrier_clone = Arc::clone(&barrier);
+        let scheduler_clone = Arc::clone(&scheduler);
+        thread_handles.push(thread::spawn(move || {
+            barrier_clone.wait(); // wait for all threads to reach the barrier
+            scheduler_clone.schedule(entry);
+        }));
+    }
+
+    // wait for threads to finish and entries to be scheduled and run
+    for handle in thread_handles {
+        handle.join().unwrap();
+    }
+    thread::sleep(Duration::from_secs(10));
+
+    assert_eq!(
+        scheduler.entry_count(),
+        total_entries as u32,
+        "entry count should match after initial scheduling of entries"
+    );
+    assert_eq!(
+        entry_ids.len(),
+        total_entries as usize,
+        "entry id count should match after initial scheduling of entries"
+    );
+    assert!(
+        map.read()
+            .unwrap()
+            .iter()
+            .all(|(_, count)| *(count.lock().unwrap()) > 0),
+        "all entries should have be executed"
+    );
+
+    entry_ids.shuffle(&mut rng);
+    let removed_entries = entry_ids.split_off(total_entries / 2);
+    for removed_entry in removed_entries {
+        scheduler.cancel(removed_entry);
+    }
+
+    // wait for entries to be cancelled
+    thread::sleep(Duration::from_secs(5));
+
+    // remove all entries from map
+    map.write().unwrap().clear();
+
+    // wait for remaining entries to keep executing
+    thread::sleep(Duration::from_secs(10));
+
+    assert_eq!(
+        scheduler.entry_count(),
+        (total_entries / 2) as u32,
+        "new entry count should match after cancellations"
+    );
+    assert!(
+        map.read()
+            .unwrap()
+            .iter()
+            .all(|(_, count)| *(count.lock().unwrap()) > 0),
+        "all remaining entries should have continued to execute"
+    );
 }


### PR DESCRIPTION
Replaced code that created a thread per notification task, which was not ideal.

In addition, there's a good of amount refactoring, which is mostly about achieving loose coupling and design improvements.

